### PR TITLE
MNT: List at least one microarch_level to avoid redundant builds

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,22 +11,22 @@ jobs:
       linux_64_microarch_level1:
         CONFIG: linux_64_microarch_level1
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
         SHORT_CONFIG: linux_64_microarch_level1
       linux_64_microarch_level3:
         CONFIG: linux_64_microarch_level3
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
         SHORT_CONFIG: linux_64_microarch_level3
       linux_aarch64_:
         CONFIG: linux_aarch64_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
         SHORT_CONFIG: linux_aarch64_
       linux_ppc64le_:
         CONFIG: linux_ppc64le_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
         SHORT_CONFIG: linux_ppc64le_
   timeoutInMinutes: 360
   variables: {}

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -29,6 +29,7 @@ jobs:
       displayName: Run Windows build
       env:
         MINIFORGE_HOME: $(MINIFORGE_HOME)
+        CONDA_BLD_PATH: $(CONDA_BLD_PATH)
         PYTHONUNBUFFERED: 1
         CONFIG: $(CONFIG)
         CI: azure

--- a/.ci_support/linux_64_microarch_level1.yaml
+++ b/.ci_support/linux_64_microarch_level1.yaml
@@ -13,9 +13,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
-libblas:
-- 3.9 *netlib
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 microarch_level:
 - '1'
 target_platform:

--- a/.ci_support/linux_64_microarch_level3.yaml
+++ b/.ci_support/linux_64_microarch_level3.yaml
@@ -13,9 +13,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
-libblas:
-- 3.9 *netlib
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 microarch_level:
 - '3'
 target_platform:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -1,5 +1,3 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:
@@ -8,8 +6,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_arch:
-- aarch64
 cdt_name:
 - conda
 channel_sources:
@@ -17,8 +13,8 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
-libblas:
-- 3.9 *netlib
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+microarch_level:
+- '1'
 target_platform:
 - linux-aarch64

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -13,8 +13,8 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
-libblas:
-- 3.9 *netlib
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+microarch_level:
+- '1'
 target_platform:
 - linux-ppc64le

--- a/.ci_support/osx_64_microarch_level1.yaml
+++ b/.ci_support/osx_64_microarch_level1.yaml
@@ -14,8 +14,6 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-libblas:
-- 3.9 *netlib
 macos_machine:
 - x86_64-apple-darwin13.4.0
 microarch_level:

--- a/.ci_support/osx_64_microarch_level3.yaml
+++ b/.ci_support/osx_64_microarch_level3.yaml
@@ -14,8 +14,6 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-libblas:
-- 3.9 *netlib
 macos_machine:
 - x86_64-apple-darwin13.4.0
 microarch_level:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -14,9 +14,9 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-libblas:
-- 3.9 *netlib
 macos_machine:
 - arm64-apple-darwin20.0.0
+microarch_level:
+- '1'
 target_platform:
 - osx-arm64

--- a/.ci_support/win_64_microarch_level1.yaml
+++ b/.ci_support/win_64_microarch_level1.yaml
@@ -6,8 +6,6 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-libblas:
-- 3.9 *netlib
 microarch_level:
 - '1'
 target_platform:

--- a/.ci_support/win_64_microarch_level3.yaml
+++ b/.ci_support/win_64_microarch_level3.yaml
@@ -6,8 +6,6 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-libblas:
-- 3.9 *netlib
 microarch_level:
 - '3'
 target_platform:

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -6,8 +6,9 @@ source .scripts/logging_utils.sh
 
 set -xe
 
-MINIFORGE_HOME=${MINIFORGE_HOME:-${HOME}/miniforge3}
-MINIFORGE_HOME=${MINIFORGE_HOME%/} # remove trailing slash
+MINIFORGE_HOME="${MINIFORGE_HOME:-${HOME}/miniforge3}"
+MINIFORGE_HOME="${MINIFORGE_HOME%/}" # remove trailing slash
+export CONDA_BLD_PATH="${CONDA_BLD_PATH:-${MINIFORGE_HOME}/conda-bld}"
 
 ( startgroup "Provisioning base env with micromamba" ) 2> /dev/null
 MICROMAMBA_VERSION="1.5.10-0"

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -36,6 +36,7 @@ if !errorlevel! neq 0 exit /b !errorlevel!
 echo Removing %MAMBA_ROOT_PREFIX%
 del /S /Q "%MAMBA_ROOT_PREFIX%" >nul
 del /S /Q "%MICROMAMBA_TMPDIR%" >nul
+call :end_group
 
 call :start_group "Configuring conda"
 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,4 @@
-microarch_level:  # [x86_64]
-  - 1  # [x86_64]
+microarch_level:
+  - 1
   - 3  # [x86_64]
   # - 4  # [linux and x86_64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "libblasfeo" %}
 {% set version = "0.1.4.1" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 package:
   name: {{ name }}


### PR DESCRIPTION
Motivation: https://github.com/conda-forge/microarch-level-feedstock/issues/11

* Always list a `microarch_level` in `recipe/conda_build_config.yaml` to avoid `conda-build` searching for and setting an incorrect `microarch_level`, resulting in redundant builds.
   - c.f. https://github.com/conda-forge/conda-forge.github.io/pull/2197
* Bump build number.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
